### PR TITLE
Parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,16 @@ arguments to input.schema.url corresponds to the ordering of the -input args to 
 	-input /data/episodes.avro \
 	-output multijson
 
+Streaming input from Parquet file (Parquet output not yet supported):
+
+	hadoop jar hadoop-streaming-2.0.0-mr1-cdh4.1.2.jar \
+    -libjars avro-json-1.0-SNAPSHOT.jar \
+    -Dinput.schema.url=file:///doctors.avsc \
+    -Doutput.schema.url=file:///doctors.avsc \
+    -Dparquet.read.support.class=parquet.avro.AvroReadSupport \
+    -inputformat com.cloudera.science.avro.streaming.ParquetAsJSONInputFormat \
+    -outputformat com.cloudera.science.avro.streaming.AvroAsJSONOutputFormat \
+    -mapper '/bin/cat' \
+    -input doctors.avro \
+    -output foo
+

--- a/pom.xml
+++ b/pom.xml
@@ -21,18 +21,21 @@
 
   <groupId>com.cloudera.science</groupId>
   <artifactId>avro-json</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.5-PARQUET-${cdh.version}</version>
   <packaging>jar</packaging>
 
   <name>Avro/JSON InputFormat/OutputFormats and SerDes</name>
   <url>http://www.cloudera.com</url>
 
   <properties>
+    <cdh.version>cdh5.2.5</cdh.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <eclipse.output.directory>eclipse-classes</eclipse.output.directory>
-    <avro.version>1.7.5</avro.version>
-    <hive.version>0.9.0-cdh4.1.3</hive.version>
-    <hadoop.version>2.0.0-cdh4.1.3</hadoop.version>
+    <avro.version>1.7.6-${cdh.version}</avro.version>
+    <hive.version>0.13.1-${cdh.version}</hive.version>
+    <hadoop.version>2.5.0-mr1-${cdh.version}</hadoop.version>
+    <parquet.version>1.6.0rc7</parquet.version>
+    <commons.cli.version>1.2</commons.cli.version>
   </properties>
 
   <build>
@@ -60,6 +63,9 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <outputFile>target/avro-json-with-dependencies-${cdh.version}.jar</outputFile>
+        </configuration>
       </plugin>
     </plugins>
 
@@ -87,6 +93,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.twitter</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <version>${parquet.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>${avro.version}</version>
@@ -98,6 +110,13 @@
       <version>${avro.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>commons-cli</groupId>
+      <artifactId>commons-cli</artifactId>
+      <version>${commons.cli.version}</version>
+    </dependency>
+
+
     <!-- Hadoop Dependencies -->
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -105,12 +124,19 @@
       <version>${hive.version}</version>
       <scope>provided</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>${hadoop.version}</version>
-      <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-core</artifactId>
+      <version>${hadoop.version}</version>
+    </dependency>
+
   </dependencies>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>com.cloudera.science</groupId>
   <artifactId>avro-json</artifactId>
-  <version>1.5-PARQUET-${cdh.version}</version>
+  <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Avro/JSON InputFormat/OutputFormats and SerDes</name>

--- a/src/main/java/com/cloudera/science/avro/common/JsonConverter.java
+++ b/src/main/java/com/cloudera/science/avro/common/JsonConverter.java
@@ -100,7 +100,12 @@ public class JsonConverter<T extends GenericRecord> {
   }
   
   public T convert(String json) throws IOException {
-    return (T) convert(mapper.readValue(json, Map.class), baseSchema);
+    try {
+        return (T) convert(mapper.readValue(json, Map.class), baseSchema);
+    }
+    catch (IOException e) {
+        throw new IOException("Failed to parse as Json: "+ json + "\n\n" + e.getMessage());
+    }
   }
   
   private T convert(Map<String, Object> raw, Schema schema)

--- a/src/main/java/com/cloudera/science/avro/common/QualityReporter.java
+++ b/src/main/java/com/cloudera/science/avro/common/QualityReporter.java
@@ -45,6 +45,7 @@ public class QualityReporter {
   public void reportMissingFields(Collection<String> missingFieldNames) {
     if (!missingFieldNames.isEmpty()) {
       inc(TOP_LEVEL_GROUP, TL_COUNTER_RECORD_HAS_MISSING_FIELDS);
+      //Note:  The following can cause issues with very wide tables.
       for (String missingFieldName : missingFieldNames) {
         inc(FIELD_MISSING_GROUP, missingFieldName);
       }

--- a/src/main/java/com/cloudera/science/avro/streaming/ParquetAsJSONInputFormat.java
+++ b/src/main/java/com/cloudera/science/avro/streaming/ParquetAsJSONInputFormat.java
@@ -1,0 +1,98 @@
+package com.cloudera.science.avro.streaming;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import parquet.avro.AvroReadSupport;
+import parquet.hadoop.mapred.Container;
+import parquet.hadoop.mapred.DeprecatedParquetInputFormat;
+
+import java.io.IOException;
+
+public class ParquetAsJSONInputFormat extends AvroAsJSONInputFormat {
+
+    private DeprecatedParquetInputFormat<IndexedRecord> realInputFormat = new DeprecatedParquetInputFormat<IndexedRecord>();
+
+    /**
+     * key to configure the ReadSupport implementation
+     */
+    public static final String READ_SUPPORT_CLASS = "parquet.read.support.class";
+    public static final Log LOG =
+            LogFactory.getLog(ParquetAsJSONInputFormat.class);
+
+    @Override
+    public RecordReader<Text, Text> getRecordReader(InputSplit split, JobConf job, Reporter reporter) throws IOException {
+
+        LOG.debug("Entering getRecordReader");
+        RecordReader<Void, Container<IndexedRecord>> realRecordReader = realInputFormat.getRecordReader(split, job, reporter);
+
+        return new ParquetAsJSONRecordReader(realRecordReader, split);
+    }
+
+    @Override
+    public InputSplit[] getSplits(JobConf job, int numSplits) throws IOException {
+        job.set(READ_SUPPORT_CLASS, AvroReadSupport.class.getName());
+        return realInputFormat.getSplits(job, numSplits);
+    }
+
+
+
+    private static class ParquetAsJSONRecordReader implements RecordReader<Text, Text> {
+
+        RecordReader<Void, Container<IndexedRecord>> realRecordReader;
+        private Container<IndexedRecord> realValue = null;
+        private GenericRecord datum = null;
+        private Void realKey = null;
+
+        private long splitLen; // for getPos()
+
+        public ParquetAsJSONRecordReader(RecordReader<Void, Container<IndexedRecord>> recordReader, InputSplit split)
+            throws IOException {
+            realRecordReader = recordReader;
+            realValue = recordReader.createValue();
+            splitLen = split.getLength();
+        }
+
+        @Override
+        public boolean next(Text key, Text value) throws IOException {
+            if (realRecordReader.next(realKey, realValue)) {
+                datum = (GenericRecord) realValue.get();
+                key.set(datum.toString());
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        public Text createKey() {
+            return new Text();
+        }
+
+        @Override
+        public Text createValue() {
+            return new Text();
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return (long) (splitLen * getProgress());
+        }
+
+        @Override
+        public void close() throws IOException {
+            realRecordReader.close();
+        }
+
+        @Override
+        public float getProgress() throws IOException {
+            return realRecordReader.getProgress();
+        }
+    }
+}
+

--- a/src/test/java/com/cloudera/science/avro/TestParquetAsJSONRecordReader.java
+++ b/src/test/java/com/cloudera/science/avro/TestParquetAsJSONRecordReader.java
@@ -1,0 +1,122 @@
+package com.cloudera.science.avro.streaming;
+
+import java.io.File;
+
+import org.apache.avro.RandomData;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.*;
+import org.apache.hadoop.fs.FileUtil;
+
+import org.junit.Test;
+import org.junit.Assert;
+import parquet.avro.AvroParquetWriter;
+
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.HashMap;
+
+public class TestParquetAsJSONRecordReader {
+
+    private static Path outDir = new Path(System.getProperty("test.build.data",
+            "/tmp"), "TestParquetAsJSONRecordReader");
+
+    private static String[] schemaStrings = new String[] {
+            "{\"type\": \"record\", \"name\": \"org.foo.Foo\",\n"+
+            " \"fields\": [ {\"name\": \"x\", \"type\": \"int\"}, {\"name\": \"y\", \"type\": \"string\"} ]\n"+
+            "}",
+            "{\"type\": \"record\", \"name\": \"org.foo.Foo\",\n"+
+            " \"fields\": [ {\"name\": \"x\", \"type\": \"int\"}, {\"name\": \"y\", \"type\": \"string\"}, "+
+                "{\"name\": \"z\", \"type\": \"string\"}]}",
+            "{\"type\": \"record\", \"name\": \"org.foo.Foo\",\n"+
+                    " \"fields\": [ {\"name\": \"x\", \"type\": \"int\"}, {\"name\": \"y\", \"type\": \"string\"} ]\n"+
+                    "}",
+    };
+
+    private static Schema[] schemas = {
+            new Schema.Parser().parse(schemaStrings[0]),
+            new Schema.Parser().parse(schemaStrings[1]),
+            new Schema.Parser().parse(schemaStrings[2])
+    };
+
+    private static final Log LOG = LogFactory.getLog(ParquetAsJSONInputFormat.class);
+
+    private static void createRandomData(Path p, Schema schema) {
+
+        try {
+            AvroParquetWriter<GenericRecord> writer = new AvroParquetWriter<GenericRecord>(p, schema);
+            for (Object datum : new RandomData(schema, 5))
+                writer.write((GenericRecord) datum);
+
+            writer.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testRecordReader() throws IOException{
+
+        JobConf conf = new JobConf();
+        conf.set("fs.defaultFS", "file:///");
+        FileSystem localFs = FileSystem.getLocal(conf);
+
+        Path[] paths = new Path[3];
+        long[] fileLength = new long[3];
+        File[] files = new File[3];
+        HashMap<String, Schema> pathSchemas = new HashMap<String, Schema>();
+        //Text key = new Text();
+        //Text value = new Text();
+        ParquetAsJSONInputFormat inputFormat = new ParquetAsJSONInputFormat();
+
+        try {
+            //Create three test Parquet files
+            for(int i=0;i<3;i++) {
+                File dir = new File(outDir.toString());
+                dir.mkdir();
+                files[i] = new File(dir,"testfile"+i+".parquet");
+                paths[i] = new Path(outDir + "/testfile"+i+".parquet").makeQualified(localFs);
+                createRandomData(paths[i], schemas[i]);
+                fileLength[i] = files[i].length();
+                pathSchemas.put(paths[i].toString(), schemas[i]);
+            }
+
+            Reporter reporter = Reporter.NULL;
+            FileInputFormat.setInputPaths(conf, outDir);
+            InputSplit[] splits = inputFormat.getSplits(conf, 2);
+
+            int count = 0;
+            for (int i=0;i<3; i++) {
+                int subcount = 0;
+                RecordReader<Text, Text> reader = inputFormat.getRecordReader(splits[i], conf, reporter);
+                Text key = reader.createKey();
+                Class keyClass = key.getClass();
+                Text value = reader.createValue();
+                Class valueClass = value.getClass();
+                Assert.assertEquals("Key class is Text.", Text.class, keyClass);
+                Assert.assertEquals("Value class is Text.", Text.class, valueClass);
+
+
+                while (reader.next(key, value)) {
+                    count += 1;
+                    subcount += 1;
+                    System.err.println("key: " + key.toString() + "\t" + "value: " + value.toString() + "\n");
+
+                }
+                Assert.assertEquals(5, subcount);
+            }
+
+            Assert.assertEquals(15, count);
+        } finally {
+            FileUtil.fullyDelete(new File(outDir.toString()));
+        }
+
+    }
+}


### PR DESCRIPTION
Adding ParquetAsJSONInputFormat to enable reading from
    Parquet files to JSON.

```
Refactored AvroAsJSONInputFormat to allow ParquetAsJSONInputFormat
to share logic for loading schema and path information
from command line parameters.
```
